### PR TITLE
Create simple Golang arbitrage service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-bullseye AS build
+WORKDIR /app
+COPY . .
+RUN go build -o arbitrage ./cmd/server
+
+FROM debian:bullseye-slim
+WORKDIR /app
+COPY --from=build /app/arbitrage /app/arbitrage
+CMD ["/app/arbitrage"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # arbitrage-detector
-Service to detect arbitrage patterns on the latest forex exchange
+
+This service generates dummy forex arbitrage opportunities on a daily basis and exposes an API to fetch the top opportunities for the day. Data is stored in a simple JSON file.
+
+## Building and running
+
+```bash
+# Build docker images and run
+docker-compose up --build
+```
+
+The service will be available on `http://localhost:8080/opportunities/top`.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/api"
+	"github.com/example/arbitrage-detector/internal/db"
+	"github.com/example/arbitrage-detector/internal/service"
+)
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	database, err := db.New("data.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	svc := &service.Service{DB: database}
+	svc.StartScheduler()
+
+	server := &api.Server{DB: database}
+	log.Println("Starting server on :8080")
+	if err := server.Start(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  arbitrage:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - data:/app
+volumes:
+  data:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/arbitrage-detector
+
+go 1.23.8

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/db"
+)
+
+// Server exposes HTTP endpoints.
+type Server struct {
+	DB *db.DB
+}
+
+// Start runs the HTTP server on the given addr.
+func (s *Server) Start(addr string) error {
+	http.HandleFunc("/opportunities/top", s.handleTop)
+	return http.ListenAndServe(addr, nil)
+}
+
+func (s *Server) handleTop(w http.ResponseWriter, r *http.Request) {
+	ops := s.DB.TopOpportunities(10, time.Now())
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(ops)
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/db"
+	"github.com/example/arbitrage-detector/internal/model"
+)
+
+func TestHandleTop(t *testing.T) {
+	tmp, err := os.CreateTemp("", "apidb-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	os.Remove(path)
+	defer os.Remove(path)
+
+	d, err := db.New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		_ = d.Insert(model.Opportunity{CurrencyPair: "EUR/USD", Profit: float64(10 - i), CreatedAt: now})
+	}
+
+	s := &Server{DB: d}
+	req := httptest.NewRequest(http.MethodGet, "/opportunities/top", nil)
+	w := httptest.NewRecorder()
+	s.handleTop(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d", w.Code)
+	}
+
+	var ops []model.Opportunity
+	if err := json.Unmarshal(w.Body.Bytes(), &ops); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(ops) != 3 {
+		t.Fatalf("expected 3 ops, got %d", len(ops))
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,101 @@
+package db
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/model"
+)
+
+// DB is a simple file-based storage.
+type DB struct {
+	filePath string
+	mu       sync.Mutex
+	data     []model.Opportunity
+	nextID   int
+}
+
+// New creates a new database backed by the given file.
+func New(file string) (*DB, error) {
+	d := &DB{filePath: file}
+	if err := d.load(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// load reads opportunities from file if it exists.
+func (d *DB) load() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	f, err := os.Open(d.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			d.data = []model.Opportunity{}
+			d.nextID = 1
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	if err := json.NewDecoder(f).Decode(&d.data); err != nil {
+		return err
+	}
+	// set nextID
+	maxID := 0
+	for _, o := range d.data {
+		if o.ID > maxID {
+			maxID = o.ID
+		}
+	}
+	d.nextID = maxID + 1
+	return nil
+}
+
+// save writes opportunities to file.
+func (d *DB) save() error {
+	f, err := os.Create(d.filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewEncoder(f).Encode(d.data)
+}
+
+// Insert adds a new opportunity to the DB.
+func (d *DB) Insert(o model.Opportunity) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	o.ID = d.nextID
+	d.nextID++
+	d.data = append(d.data, o)
+	return d.save()
+}
+
+// TopOpportunities returns top n opportunities for the given date (local time).
+func (d *DB) TopOpportunities(n int, day time.Time) []model.Opportunity {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	start := time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, day.Location())
+	end := start.Add(24 * time.Hour)
+
+	var todays []model.Opportunity
+	for _, o := range d.data {
+		if !o.CreatedAt.Before(start) && o.CreatedAt.Before(end) {
+			todays = append(todays, o)
+		}
+	}
+	sort.Slice(todays, func(i, j int) bool { return todays[i].Profit > todays[j].Profit })
+	if len(todays) > n {
+		todays = todays[:n]
+	}
+	result := make([]model.Opportunity, len(todays))
+	copy(result, todays)
+	return result
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/model"
+)
+
+func TestInsertAndTopOpportunities(t *testing.T) {
+	tmp, err := os.CreateTemp("", "dbtest-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	os.Remove(path)
+	defer os.Remove(path)
+
+	d, err := New(path)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	day := time.Now()
+	for i := 0; i < 5; i++ {
+		o := model.Opportunity{
+			CurrencyPair: "EUR/USD",
+			Profit:       float64(i),
+			CreatedAt:    day,
+		}
+		if err := d.Insert(o); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	ops := d.TopOpportunities(3, day)
+	if len(ops) != 3 {
+		t.Fatalf("expected 3 ops, got %d", len(ops))
+	}
+	if ops[0].Profit < ops[1].Profit {
+		t.Errorf("results not sorted desc")
+	}
+}

--- a/internal/model/opportunity.go
+++ b/internal/model/opportunity.go
@@ -1,0 +1,11 @@
+package model
+
+import "time"
+
+// Opportunity represents a forex arbitrage opportunity.
+type Opportunity struct {
+	ID           int       `json:"id"`
+	CurrencyPair string    `json:"currency_pair"`
+	Profit       float64   `json:"profit"`
+	CreatedAt    time.Time `json:"created_at"`
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,7 +1,10 @@
 package service
 
 import (
-	"math/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/example/arbitrage-detector/internal/db"
@@ -9,12 +12,66 @@ import (
 )
 
 // Service coordinates fetching opportunities and storing them.
+type RateProvider interface {
+	GetRate(base, quote string) (float64, error)
+}
+
 type Service struct {
-	DB *db.DB
+	DB        *db.DB
+	ProviderA RateProvider
+	ProviderB RateProvider
+	MinSpread float64
+}
+
+// defaultProviderA fetches rates from exchangerate.host
+type defaultProviderA struct{ client *http.Client }
+
+func (p defaultProviderA) GetRate(base, quote string) (float64, error) {
+	url := fmt.Sprintf("https://api.exchangerate.host/latest?base=%s&symbols=%s", base, quote)
+	resp, err := p.client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var m struct {
+		Rates map[string]float64 `json:"rates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return 0, err
+	}
+	return m.Rates[quote], nil
+}
+
+// defaultProviderB fetches rates from open.er-api.com
+type defaultProviderB struct{ client *http.Client }
+
+func (p defaultProviderB) GetRate(base, quote string) (float64, error) {
+	url := fmt.Sprintf("https://open.er-api.com/v6/latest/%s", base)
+	resp, err := p.client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var m struct {
+		Rates map[string]float64 `json:"rates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return 0, err
+	}
+	return m.Rates[quote], nil
 }
 
 // StartScheduler starts a goroutine that fetches data daily.
 func (s *Service) StartScheduler() {
+	if s.ProviderA == nil {
+		s.ProviderA = defaultProviderA{client: http.DefaultClient}
+	}
+	if s.ProviderB == nil {
+		s.ProviderB = defaultProviderB{client: http.DefaultClient}
+	}
+	if s.MinSpread == 0 {
+		s.MinSpread = 0.1
+	}
 	go func() {
 		s.fetchAndStore()
 		ticker := time.NewTicker(24 * time.Hour)
@@ -27,12 +84,38 @@ func (s *Service) StartScheduler() {
 // fetchAndStore generates fake opportunities and stores them.
 func (s *Service) fetchAndStore() {
 	pairs := []string{"EUR/USD", "USD/JPY", "GBP/USD", "USD/CHF", "AUD/USD"}
-	for i := 0; i < 20; i++ {
-		o := model.Opportunity{
-			CurrencyPair: pairs[rand.Intn(len(pairs))],
-			Profit:       rand.Float64() * 5,
-			CreatedAt:    time.Now(),
+	for _, pair := range pairs {
+		parts := strings.Split(pair, "/")
+		if len(parts) != 2 {
+			continue
 		}
-		_ = s.DB.Insert(o)
+		base, quote := parts[0], parts[1]
+		r1, err1 := s.ProviderA.GetRate(base, quote)
+		r2, err2 := s.ProviderB.GetRate(base, quote)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+
+		if r1 < r2 {
+			spread := (r2 - r1) / r1 * 100
+			if spread >= s.MinSpread {
+				o := model.Opportunity{
+					CurrencyPair: pair,
+					Profit:       spread,
+					CreatedAt:    time.Now(),
+				}
+				_ = s.DB.Insert(o)
+			}
+		} else if r2 < r1 {
+			spread := (r1 - r2) / r2 * 100
+			if spread >= s.MinSpread {
+				o := model.Opportunity{
+					CurrencyPair: pair,
+					Profit:       spread,
+					CreatedAt:    time.Now(),
+				}
+				_ = s.DB.Insert(o)
+			}
+		}
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/db"
+	"github.com/example/arbitrage-detector/internal/model"
+)
+
+// Service coordinates fetching opportunities and storing them.
+type Service struct {
+	DB *db.DB
+}
+
+// StartScheduler starts a goroutine that fetches data daily.
+func (s *Service) StartScheduler() {
+	go func() {
+		s.fetchAndStore()
+		ticker := time.NewTicker(24 * time.Hour)
+		for range ticker.C {
+			s.fetchAndStore()
+		}
+	}()
+}
+
+// fetchAndStore generates fake opportunities and stores them.
+func (s *Service) fetchAndStore() {
+	pairs := []string{"EUR/USD", "USD/JPY", "GBP/USD", "USD/CHF", "AUD/USD"}
+	for i := 0; i < 20; i++ {
+		o := model.Opportunity{
+			CurrencyPair: pairs[rand.Intn(len(pairs))],
+			Profit:       rand.Float64() * 5,
+			CreatedAt:    time.Now(),
+		}
+		_ = s.DB.Insert(o)
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/db"
+)
+
+func TestFetchAndStore(t *testing.T) {
+	tmp, err := os.CreateTemp("", "svcdb-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	os.Remove(path)
+	defer os.Remove(path)
+
+	d, err := db.New(path)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+
+	pA := stubProvider{rate: 1.0}
+	pB := stubProvider{rate: 1.1}
+	svc := &Service{DB: d, ProviderA: pA, ProviderB: pB}
+	svc.fetchAndStore()
+
+	if len(d.TopOpportunities(100, time.Now())) == 0 {
+		t.Error("expected opportunities inserted")
+	}
+}
+
+type stubProvider struct {
+	rate float64
+	err  error
+}
+
+func (s stubProvider) GetRate(base, quote string) (float64, error) {
+	return s.rate, s.err
+}


### PR DESCRIPTION
## Summary
- add Go module and implementation for a simple arbitrage service
- store opportunities in a JSON file and schedule daily refreshes
- expose HTTP API for top daily opportunities
- add Dockerfile and docker-compose setup

## Testing
- `go build ./...`
- ran the service and queried `http://localhost:8080/opportunities/top`