### PR TITLE
Integrate real forex rates

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/db"
+	"github.com/example/arbitrage-detector/internal/model"
+)
+
+func TestHandleTop(t *testing.T) {
+	tmp, err := os.CreateTemp("", "apidb-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	os.Remove(path)
+	defer os.Remove(path)
+
+	d, err := db.New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		_ = d.Insert(model.Opportunity{CurrencyPair: "EUR/USD", Profit: float64(10 - i), CreatedAt: now})
+	}
+
+	s := &Server{DB: d}
+	req := httptest.NewRequest(http.MethodGet, "/opportunities/top", nil)
+	w := httptest.NewRecorder()
+	s.handleTop(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d", w.Code)
+	}
+
+	var ops []model.Opportunity
+	if err := json.Unmarshal(w.Body.Bytes(), &ops); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(ops) != 3 {
+		t.Fatalf("expected 3 ops, got %d", len(ops))
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/model"
+)
+
+func TestInsertAndTopOpportunities(t *testing.T) {
+	tmp, err := os.CreateTemp("", "dbtest-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	os.Remove(path)
+	defer os.Remove(path)
+
+	d, err := New(path)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	day := time.Now()
+	for i := 0; i < 5; i++ {
+		o := model.Opportunity{
+			CurrencyPair: "EUR/USD",
+			Profit:       float64(i),
+			CreatedAt:    day,
+		}
+		if err := d.Insert(o); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	ops := d.TopOpportunities(3, day)
+	if len(ops) != 3 {
+		t.Fatalf("expected 3 ops, got %d", len(ops))
+	}
+	if ops[0].Profit < ops[1].Profit {
+		t.Errorf("results not sorted desc")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,7 +1,10 @@
 package service
 
 import (
-	"math/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/example/arbitrage-detector/internal/db"
@@ -9,12 +12,66 @@ import (
 )
 
 // Service coordinates fetching opportunities and storing them.
+type RateProvider interface {
+	GetRate(base, quote string) (float64, error)
+}
+
 type Service struct {
-	DB *db.DB
+	DB        *db.DB
+	ProviderA RateProvider
+	ProviderB RateProvider
+	MinSpread float64
+}
+
+// defaultProviderA fetches rates from exchangerate.host
+type defaultProviderA struct{ client *http.Client }
+
+func (p defaultProviderA) GetRate(base, quote string) (float64, error) {
+	url := fmt.Sprintf("https://api.exchangerate.host/latest?base=%s&symbols=%s", base, quote)
+	resp, err := p.client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var m struct {
+		Rates map[string]float64 `json:"rates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return 0, err
+	}
+	return m.Rates[quote], nil
+}
+
+// defaultProviderB fetches rates from open.er-api.com
+type defaultProviderB struct{ client *http.Client }
+
+func (p defaultProviderB) GetRate(base, quote string) (float64, error) {
+	url := fmt.Sprintf("https://open.er-api.com/v6/latest/%s", base)
+	resp, err := p.client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var m struct {
+		Rates map[string]float64 `json:"rates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return 0, err
+	}
+	return m.Rates[quote], nil
 }
 
 // StartScheduler starts a goroutine that fetches data daily.
 func (s *Service) StartScheduler() {
+	if s.ProviderA == nil {
+		s.ProviderA = defaultProviderA{client: http.DefaultClient}
+	}
+	if s.ProviderB == nil {
+		s.ProviderB = defaultProviderB{client: http.DefaultClient}
+	}
+	if s.MinSpread == 0 {
+		s.MinSpread = 0.1
+	}
 	go func() {
 		s.fetchAndStore()
 		ticker := time.NewTicker(24 * time.Hour)
@@ -27,12 +84,38 @@ func (s *Service) StartScheduler() {
 // fetchAndStore generates fake opportunities and stores them.
 func (s *Service) fetchAndStore() {
 	pairs := []string{"EUR/USD", "USD/JPY", "GBP/USD", "USD/CHF", "AUD/USD"}
-	for i := 0; i < 20; i++ {
-		o := model.Opportunity{
-			CurrencyPair: pairs[rand.Intn(len(pairs))],
-			Profit:       rand.Float64() * 5,
-			CreatedAt:    time.Now(),
+	for _, pair := range pairs {
+		parts := strings.Split(pair, "/")
+		if len(parts) != 2 {
+			continue
 		}
-		_ = s.DB.Insert(o)
+		base, quote := parts[0], parts[1]
+		r1, err1 := s.ProviderA.GetRate(base, quote)
+		r2, err2 := s.ProviderB.GetRate(base, quote)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+
+		if r1 < r2 {
+			spread := (r2 - r1) / r1 * 100
+			if spread >= s.MinSpread {
+				o := model.Opportunity{
+					CurrencyPair: pair,
+					Profit:       spread,
+					CreatedAt:    time.Now(),
+				}
+				_ = s.DB.Insert(o)
+			}
+		} else if r2 < r1 {
+			spread := (r1 - r2) / r2 * 100
+			if spread >= s.MinSpread {
+				o := model.Opportunity{
+					CurrencyPair: pair,
+					Profit:       spread,
+					CreatedAt:    time.Now(),
+				}
+				_ = s.DB.Insert(o)
+			}
+		}
 	}
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/example/arbitrage-detector/internal/db"
+)
+
+func TestFetchAndStore(t *testing.T) {
+	tmp, err := os.CreateTemp("", "svcdb-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	os.Remove(path)
+	defer os.Remove(path)
+
+	d, err := db.New(path)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+
+	pA := stubProvider{rate: 1.0}
+	pB := stubProvider{rate: 1.1}
+	svc := &Service{DB: d, ProviderA: pA, ProviderB: pB}
+	svc.fetchAndStore()
+
+	if len(d.TopOpportunities(100, time.Now())) == 0 {
+		t.Error("expected opportunities inserted")
+	}
+}
+
+type stubProvider struct {
+	rate float64
+	err  error
+}
+
+func (s stubProvider) GetRate(base, quote string) (float64, error) {
+	return s.rate, s.err
+}


### PR DESCRIPTION
## Summary
- replace random opportunities with real forex rates
- implement `RateProvider` interface with two open APIs
- compute arbitrage spreads using real rate providers
- update service tests with stub providers

## Testing
- `go test ./...`